### PR TITLE
TDH provisions its own key in its permission database

### DIFF
--- a/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/CouchDBListener/ThaliListener.java
+++ b/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/CouchDBListener/ThaliListener.java
@@ -15,10 +15,7 @@ package com.msopentech.thali.CouchDBListener;
 
 import Acme.Serve.SSLAcceptor;
 import Acme.Serve.Serve;
-import com.couchbase.lite.Context;
-import com.couchbase.lite.CouchbaseLiteException;
-import com.couchbase.lite.Manager;
-import com.couchbase.lite.ManagerOptions;
+import com.couchbase.lite.*;
 import com.couchbase.lite.auth.AuthorizerFactory;
 import com.couchbase.lite.auth.AuthorizerFactoryManager;
 import com.couchbase.lite.listener.LiteListener;
@@ -90,6 +87,10 @@ public class ThaliListener {
                     // This creates the database used to store the keys of remote applications that are authorized to use
                     // the system in case it doesn't already exist.
                     manager.getDatabase(KeyDatabaseName);
+
+                    // Provision the TDH in its own key database so it can do replications to itself
+                    // https://github.com/thaliproject/thali/issues/45
+                    BogusAuthorizeCouchDocument.addDocViaManager(manager, (java.security.interfaces.RSAPublicKey) serverPublicKey);
                 } catch (IOException e) {
                     Log.e(CblLogTags.TAG_THALI_LISTENER, "Manager failed to start", e);
                     return;

--- a/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/utilities/universal/test/ConfigureRequestObjects.java
+++ b/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/utilities/universal/test/ConfigureRequestObjects.java
@@ -101,11 +101,6 @@ public class ConfigureRequestObjects {
         replicationDatabaseConnector = thaliCouchDbInstance.createConnector(
                 ThaliTestEktorpClient.ReplicationTestDatabaseName, false);
 
-        // Last but not least we need to provision the databases own key inside itself. The reason is
-        // that we are doing replication tests where the database talks to itself. So if its own key isn't
-        // in its own authorization database then it won't let itself talk to itself!
-        ThaliClientToDeviceHubUtilities.configureKeyInServersKeyDatabase(serverPublicKey, thaliCouchDbInstance);
-
         HttpClient torHttpClient = createClientBuilder.CreateEktorpClient(tdhOnionHost, tdhOnionPort, serverPublicKey,
                 clientKeyStore, passPhrase, onionProxy);
         torThaliCouchDbInstance = new ThaliCouchDbInstance(torHttpClient);


### PR DESCRIPTION
That way it can replicate things to itself. This is useful both for testing
but also for production.
