### PR TITLE
Remove redundant build tasks

### DIFF
--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -4,16 +4,6 @@ apply plugin: 'distribution'
 sourceCompatibility = 1.6
 version = '0.0.2'
 
-/*
-This script depends on the layout of depots. It assumes a file structure of
-some directory
-    couchbase-list-java-native
-    ...
-    thali
-
-In other words that there is a single directory that contains all the relevant depots below including Thali.
- */
-
 // You can pass in -PskipAndroidTest on the command line to skip android tests
 def runAndroidTest(buildTask, runTest = true) {
    if (runTest == false || project.hasProperty('skipAndroidTest')) {
@@ -22,58 +12,6 @@ def runAndroidTest(buildTask, runTest = true) {
        return ['connectedAndroidTest', buildTask];
    }
 }
-
-task buildTorOnionProxyLibraryUniversal(type: GradleBuild) {
-    buildFile = '../../Tor_Onion_Proxy_Library/universal/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = ['test', 'uploadArchives']
-}
-
-task buildTorOnionProxyLibraryJava(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryUniversal') {
-    buildFile = '../../Tor_Onion_Proxy_Library/java/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = ['test', 'uploadArchives']
-}
-
-task buildTorOnionProxyLibraryAndroid(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryJava') {
-    buildFile = '../../Tor_Onion_Proxy_Library/android/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = runAndroidTest('uploadArchives')
-}
-
-task buildCouchbaseLiteJavaNative(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryAndroid') {
-    buildFile = '../../couchbase-lite-java-native/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = ['test', 'uploadArchives']
-}
-
-task buildCouchbaseLiteJavaCore(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaNative') {
-    buildFile = '../../couchbase-lite-java-core/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = ['test', 'uploadArchives']
-}
-
-task buildCouchbaseLiteJavaListener(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaCore') {
-    buildFile = '../../couchbase-lite-java-listener/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = ['test', 'uploadArchives']
-}
-
-task buildCouchbaseLiteAndroid(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaListener') {
-    buildFile = '../../couchbase-lite-android/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = runAndroidTest('uploadArchives', false)
-}
-
-task buildCouchbaseLiteJava(type: GradleBuild, dependsOn: 'buildCouchbaseLiteAndroid') {
-    buildFile = '../../couchbase-lite-java/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = [/*'test',*/ 'uploadArchives']
-}
-
-// NOTE: I AM NOT BUILDING EKTORP! We haven't edited it in forever, it uses maven to build and not gradle and I
-// need to check if they finally released the version with our changes so we can stop thinking about it all together (e.g.
-// stop using the snapshot)
 
 task buildThaliUniversalUtilities(type: GradleBuild) {
     buildFile = 'Utilities/UniversalUtilities/build.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ task buildTorOnionProxyLibraryUniversal(type: GradleBuild) {
 task buildTorOnionProxyLibraryJava(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryUniversal') {
     buildFile = '../Tor_Onion_Proxy_Library/java/build.gradle'
     startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = [/*'test',*/ 'uploadArchives']
+    tasks = ['test', 'uploadArchives']
 }
 
 task buildTorOnionProxyLibraryAndroid(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryJava') {
@@ -72,7 +72,7 @@ task buildCouchbaseLiteAndroid(type: GradleBuild, dependsOn: 'buildCouchbaseLite
 task buildCouchbaseLiteJava(type: GradleBuild, dependsOn: 'buildCouchbaseLiteAndroid') {
     buildFile = '../couchbase-lite-java/build.gradle'
     startParameter.projectProperties = gradle.startParameter.projectProperties
-    tasks = [/*'test',*/ 'uploadArchives']
+    tasks = ['test', 'uploadArchives']
 }
 // NOTE: I AM NOT BUILDING EKTORP! We haven't edited it in forever, it uses maven to build and not gradle and I
 // need to check if they finally released the version with our changes so we can stop thinking about it all together (e.g.


### PR DESCRIPTION
thali/build.gradle:
- role of this build.gradle is to orchestrate builds across repos (Couchbase, Tor, Thali)

thali/Production/build.gradle:
- will build projects in thali repo (TDH, Utilities)
