### PR TITLE
 Allow configurable version numbers for built binaries.

### DIFF
--- a/Production/ThaliDeviceHub/Universal/build.gradle
+++ b/Production/ThaliDeviceHub/Universal/build.gradle
@@ -26,26 +26,20 @@ repositories {
 }
 
 dependencies {
-    compile "com.msopentech.thali:ThaliUtilitiesUniversal:0.0.2"
+    compile 'com.msopentech.thali:ThaliUtilitiesUniversal:' + System.getProperty('MAVEN_UPLOAD_VERSION')
 
     testCompile 'junit:junit:4.11'
 	testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }
 
-def mavenPath() {
-    artifactory_local == "true" ?
-            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-            artifactory_contextUrl + "/libs-release-local"
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-			repository(url: mavenPath()) {
-				authentication(userName: "${artifactory_user}", password: "${artifactory_password}")
-			}
+            repository(url: System.getProperty('MAVEN_UPLOAD_REPO_URL')) {
+                authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD')) 
+            }
 
-            pom.version = "0.0.2"
+            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
             pom.groupId = 'com.msopentech.thali'
             pom.artifactId = 'ThaliTDHUniversal'
             pom.project {

--- a/Production/ThaliDeviceHub/android/android/build.gradle
+++ b/Production/ThaliDeviceHub/android/android/build.gradle
@@ -39,7 +39,7 @@ android {
 }
 
 dependencies {
-    compile "com.msopentech.thali:ThaliTDHUniversal:0.0.2"
-    compile "com.msopentech.thali:ThaliUtilitiesAndroid:0.0.2"
+    compile 'com.msopentech.thali:ThaliTDHUniversal:' + System.getProperty('MAVEN_UPLOAD_VERSION')
+    compile 'com.msopentech.thali:ThaliUtilitiesAndroid:' + System.getProperty('MAVEN_UPLOAD_VERSION')
     compile 'org.slf4j:slf4j-android:1.7.7'
 }

--- a/Production/ThaliDeviceHub/android/android/src/main/AndroidManifest.xml
+++ b/Production/ThaliDeviceHub/android/android/src/main/AndroidManifest.xml
@@ -4,10 +4,6 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk
-        android:minSdkVersion="18"
-        android:targetSdkVersion="18" />
-
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/Production/ThaliDeviceHub/java/build.gradle
+++ b/Production/ThaliDeviceHub/java/build.gradle
@@ -27,8 +27,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.msopentech.thali:ThaliUtilitiesJava:0.0.2'
-    compile "com.msopentech.thali:ThaliTDHUniversal:0.0.2"
+    compile 'com.msopentech.thali:ThaliUtilitiesJava:' + System.getProperty('MAVEN_UPLOAD_VERSION')
+    compile 'com.msopentech.thali:ThaliTDHUniversal:' + System.getProperty('MAVEN_UPLOAD_VERSION')
     compile 'org.slf4j:slf4j-simple:1.7.7'
 
     testCompile 'junit:junit:4.11'

--- a/Production/Utilities/AndroidUtilities/AndroidUtilities/build.gradle
+++ b/Production/Utilities/AndroidUtilities/AndroidUtilities/build.gradle
@@ -19,6 +19,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:0.10.+'
     }
 }
+
 apply plugin: 'android-library'
 apply plugin: 'maven'
 
@@ -53,10 +54,10 @@ android {
 }
 
 dependencies {
-    compile 'com.couchbase.lite:couchbase-lite-android:1.0.0-beta3rc1'
+    compile 'com.couchbase.lite:couchbase-lite-android:' + System.getProperty('MAVEN_UPLOAD_VERSION')
+    compile 'com.msopentech.thali:ThaliUtilitiesUniversal:' + System.getProperty('MAVEN_UPLOAD_VERSION')
+    compile 'com.msopentech.thali:ThaliOnionProxyAndroid:' + System.getProperty('MAVEN_UPLOAD_VERSION')
     compile 'org.ektorp:org.ektorp.android:1.4.2'
-    compile "com.msopentech.thali:ThaliUtilitiesUniversal:0.0.2"
-    compile 'com.msopentech.thali:ThaliOnionProxyAndroid:0.0.0'
 
     //fileTree(dir: 'libs', include: '*.jar')
     androidTestCompile 'org.slf4j:slf4j-android:1.7.7'
@@ -64,20 +65,14 @@ dependencies {
 
 }
 
-def mavenPath() {
-    artifactory_local == "true" ?
-            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-            artifactory_contextUrl + "/libs-release-local"
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: mavenPath()) {
-                authentication(userName: "${artifactory_user}", password: "${artifactory_password}")
+            repository(url: System.getProperty('MAVEN_UPLOAD_REPO_URL')) {
+                authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD')) 
             }
 
-            pom.version = "0.0.2"
+            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
             pom.groupId = 'com.msopentech.thali'
             pom.artifactId = 'ThaliUtilitiesAndroid'
             pom.project {

--- a/Production/Utilities/AndroidUtilities/AndroidUtilities/src/main/AndroidManifest.xml
+++ b/Production/Utilities/AndroidUtilities/AndroidUtilities/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
     android:versionCode="1"
     android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="18" android:targetSdkVersion="18" />
-
     <application android:allowBackup="true"
         android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"

--- a/Production/Utilities/JavaUtilities/build.gradle
+++ b/Production/Utilities/JavaUtilities/build.gradle
@@ -31,9 +31,9 @@ javafx {
 }
 
 dependencies {
-    compile 'com.couchbase.lite:java:1.0.0-beta3rc1'
-    compile 'com.msopentech.thali:ThaliUtilitiesUniversal:0.0.2'
-    compile 'com.msopentech.thali:ThaliOnionProxyJava:0.0.0'
+    compile 'com.couchbase.lite:java:' + System.getProperty('MAVEN_UPLOAD_VERSION')
+    compile 'com.msopentech.thali:ThaliUtilitiesUniversal:' + System.getProperty('MAVEN_UPLOAD_VERSION')
+    compile 'com.msopentech.thali:ThaliOnionProxyJava:' + System.getProperty('MAVEN_UPLOAD_VERSION')
 
     testCompile 'com.jayway.jsonpath:json-path-assert:0.9.1'
     testCompile 'junit:junit:3.8.2'
@@ -41,20 +41,14 @@ dependencies {
     testCompile 'org.seleniumhq.selenium:selenium-java:2.42.2'
 }
 
-def mavenPath() {
-    artifactory_local == "true" ?
-            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-            artifactory_contextUrl + "/libs-release-local"
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: mavenPath()) {
-                authentication(userName: "${artifactory_user}", password: "${artifactory_password}")
+            repository(url: System.getProperty('MAVEN_UPLOAD_REPO_URL')) {
+                authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD')) 
             }
 
-            pom.version = "0.0.2"
+            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
             pom.groupId = 'com.msopentech.thali'
             pom.artifactId = 'ThaliUtilitiesJava'
             pom.project {

--- a/Production/Utilities/UniversalUtilities/build.gradle
+++ b/Production/Utilities/UniversalUtilities/build.gradle
@@ -26,35 +26,29 @@ repositories {
 }
 
 dependencies {
+    compile 'com.couchbase.lite:couchbase-lite-java-core:' + System.getProperty('MAVEN_UPLOAD_VERSION')
+    compile 'com.couchbase.lite:couchbase-lite-java-listener:' + System.getProperty('MAVEN_UPLOAD_VERSION')
+    compile 'com.msopentech.thali:ThaliOnionProxyUniversal:' + System.getProperty('MAVEN_UPLOAD_VERSION')
     compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'org.bouncycastle:bcprov-jdk15on:1.49'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.49'
     compile 'org.apache.httpcomponents:httpclient:4.2.5' // Version used in Android 4.3
     compile 'org.ektorp:org.ektorp:1.4.2'
-    compile 'com.couchbase.lite:couchbase-lite-java-core:1.0.0-beta3rc1'
-    compile 'com.couchbase.lite:couchbase-lite-java-listener:1.0.0-beta3rc1'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.3.2'
     compile 'org.apache.commons:commons-lang3:3.3.1'
-    compile 'com.msopentech.thali:ThaliOnionProxyUniversal:0.0.0'
 
     testCompile 'junit:junit:4.11'
     testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }
 
-def mavenPath() {
-    artifactory_local == "true" ?
-            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-            artifactory_contextUrl + "/libs-release-local"
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: mavenPath()) {
-                authentication(userName: "${artifactory_user}", password: "${artifactory_password}")
+            repository(url: System.getProperty('MAVEN_UPLOAD_REPO_URL')) {
+                authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD')) 
             }
 
-            pom.version = "0.0.2"
+            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
             pom.groupId = 'com.msopentech.thali'
             pom.artifactId = 'ThaliUtilitiesUniversal'
             pom.project {

--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -25,8 +25,9 @@ def runAndroidTest(buildTask, runTest = true) {
 
 tasks.withType(GradleBuild) {
     ext.buildWithArtifacts = 'true'
+    ext.mavenBuildLocal = System.getProperty('MAVEN_BUILD_LOCAL') ?: true
     ext.mavenRemoteRepoUrl = System.getProperty('MAVEN_REMOTE_REPO_URL') ?: 'http://thaliartifactory.cloudapp.net/artifactory'
-    ext.mavenPath = System.getProperty('MAVEN_BUILD_LOCAL') == 'true' ?
+    ext.mavenPath = mavenBuildLocal ?
             'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
             mavenRemoteRepoUrl
 

--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -25,19 +25,14 @@ def runAndroidTest(buildTask, runTest = true) {
 
 tasks.withType(GradleBuild) {
     ext.buildWithArtifacts = 'true'
-    ext.mavenBuildLocal = System.getProperty('MAVEN_BUILD_LOCAL') ?: true
-    ext.mavenRemoteRepoUrl = System.getProperty('MAVEN_REMOTE_REPO_URL') ?: 'http://thaliartifactory.cloudapp.net/artifactory'
-    ext.mavenPath = mavenBuildLocal ?
-            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-            mavenRemoteRepoUrl
 
     startParameter.projectProperties = gradle.startParameter.projectProperties
     startParameter.systemPropertiesArgs = [
         'UPLOAD_VERSION_CBLITE'     : version,
         'MAVEN_UPLOAD_VERSION'      : version,
-        'MAVEN_UPLOAD_REPO_URL'     : mavenPath,
-        'MAVEN_UPLOAD_USERNAME'     : System.getProperty('MAVEN_UPLOAD_USERNAME')    ?: 'user',
-        'MAVEN_UPLOAD_PASSWORD'     : System.getProperty('MAVEN_UPLOAD_PASSWORD')    ?: '[*]',
+        'MAVEN_UPLOAD_REPO_URL'     : System.getProperty('MAVEN_UPLOAD_REPO_URL'),
+        'MAVEN_UPLOAD_USERNAME'     : System.getProperty('MAVEN_UPLOAD_USERNAME'),
+        'MAVEN_UPLOAD_PASSWORD'     : System.getProperty('MAVEN_UPLOAD_PASSWORD'),
 
         // flags used in couchbase projects to retrieve dependencies via Maven
         'buildAndroidWithArtifacts' : buildWithArtifacts,

--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'distribution'
 
 sourceCompatibility = 1.6
-version = '0.0.2'
+version = System.getProperty('MAVEN_UPLOAD_VERSION') ?: '1.0.0-beta3rc1'
 
 /*
 This script depends on the layout of depots. It assumes a file structure of
@@ -23,21 +23,40 @@ def runAndroidTest(buildTask, runTest = true) {
    }
 }
 
+tasks.withType(GradleBuild) {
+    ext.buildWithArtifacts = 'true'
+    ext.mavenRemoteRepoUrl = System.getProperty('MAVEN_REMOTE_REPO_URL') ?: 'http://thaliartifactory.cloudapp.net/artifactory'
+    ext.mavenPath = System.getProperty('MAVEN_BUILD_LOCAL') == 'true' ?
+            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
+            mavenRemoteRepoUrl
+
+    startParameter.projectProperties = gradle.startParameter.projectProperties
+    startParameter.systemPropertiesArgs = [
+        'UPLOAD_VERSION_CBLITE'     : version,
+        'MAVEN_UPLOAD_VERSION'      : version,
+        'MAVEN_UPLOAD_REPO_URL'     : mavenPath,
+        'MAVEN_UPLOAD_USERNAME'     : System.getProperty('MAVEN_UPLOAD_USERNAME')    ?: 'user',
+        'MAVEN_UPLOAD_PASSWORD'     : System.getProperty('MAVEN_UPLOAD_PASSWORD')    ?: '[*]',
+
+        // flags used in couchbase projects to retrieve dependencies via Maven
+        'buildAndroidWithArtifacts' : buildWithArtifacts,
+        'buildListenerWithArtifacts': buildWithArtifacts,
+        'buildAgainstMavenArtifacts': buildWithArtifacts,
+    ]
+}
+
 task buildTorOnionProxyLibraryUniversal(type: GradleBuild) {
     buildFile = '../../Tor_Onion_Proxy_Library/universal/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'uploadArchives']
 }
 
 task buildTorOnionProxyLibraryJava(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryUniversal') {
     buildFile = '../../Tor_Onion_Proxy_Library/java/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'uploadArchives']
 }
 
 task buildTorOnionProxyLibraryAndroid(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryJava') {
     buildFile = '../../Tor_Onion_Proxy_Library/android/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = runAndroidTest('uploadArchives')
 }
 
@@ -47,26 +66,22 @@ task buildTorOnionProxyLibraryAndroid(type: GradleBuild, dependsOn: 'buildTorOni
 // window I normally use.
 task buildCouchbaseLiteJavaNative(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryAndroid') {
     buildFile = '../../couchbase-lite-java-native/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'uploadArchives']
 }
 
 task buildCouchbaseLiteJavaCore(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaNative') {
     buildFile = '../../couchbase-lite-java-core/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'uploadArchives']
 }
 
 task buildCouchbaseLiteJavaListener(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaCore') {
     buildFile = '../../couchbase-lite-java-listener/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'uploadArchives']
 }
 
 // See issue 53 in the next task
 task buildCouchbaseLiteAndroid(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaListener') {
     buildFile = '../../couchbase-lite-android/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = runAndroidTest('uploadArchives', false)
 }
 
@@ -77,43 +92,36 @@ task buildCouchbaseLiteAndroid(type: GradleBuild, dependsOn: 'buildCouchbaseLite
 // https://github.com/thaliproject/thali/issues/53
 task buildCouchbaseLiteJava(type: GradleBuild, dependsOn: 'buildCouchbaseLiteAndroid') {
     buildFile = '../../couchbase-lite-java/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = [/*'test',*/ 'uploadArchives']
 }
 
 task buildThaliUniversalUtilities(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJava') {
     buildFile = 'Utilities/UniversalUtilities/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'uploadArchives']
 }
 
 task buildThaliJavaUtilities(type: GradleBuild, dependsOn: 'buildThaliUniversalUtilities') {
     buildFile = 'Utilities/JavaUtilities/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'uploadArchives']
 }
 
 task buildThaliAndroidUtilities(type: GradleBuild, dependsOn: 'buildThaliJavaUtilities') {
     buildFile = 'Utilities/AndroidUtilities/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = runAndroidTest('uploadArchives')
 }
 
 task buildThaliDeviceHubUniversal(type: GradleBuild, dependsOn: 'buildThaliAndroidUtilities') {
     buildFile = 'ThaliDeviceHub/Universal/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'uploadArchives']
 }
 
 task buildThaliDeviceHubJava(type: GradleBuild, dependsOn: 'buildThaliDeviceHubUniversal') {
     buildFile = 'ThaliDeviceHub/java/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = ['test', 'distZip'] // This isn't a library, it's an 'executable', this builds the distribution
 }
 
 task buildThaliDeviceHubAndroid(type: GradleBuild, dependsOn: 'buildThaliDeviceHubJava') {
     buildFile = 'ThaliDeviceHub/android/android/build.gradle'
-    startParameter.projectProperties = gradle.startParameter.projectProperties
     tasks = runAndroidTest('build') // This isn't a library, it's an 'executable', this builds the apk file
 }
 


### PR DESCRIPTION
Through gradle system properties (-P), able to configure:
- MAVEN_UPLOAD_VERSION = binary versions [Default Value: 1.0.0-beta3rc1]
- MAVEN_BUILD_LOCAL = if true, deploys artifacts to local repository.
  otherwise, deploys binary to MAVEN_REMOTE_REPO_URL [Default Value: true]
- MAVEN_REMOTE_REPO_URL = maven remote repo url (e.g.
  file://c:/some/directory or http://artifactory.com) [Default Value:
  http://thaliartifactory.cloudapp.net/artifactory]
- MAVEN_UPLOAD_USERNAME, MAVEN_UPLOAD_PASSWORD = credentials for
  MAVEN_REMOTE_REPO_URL [Default Value: user/[*]]

System and project properties are propagated to subsequent child gradle tasks.
