### PR TITLE
Enable relay to resolve onion address into httpkeyurls

### DIFF
--- a/Production/ThaliDeviceHub/android/android/src/main/java/com/msopentech/thali/devicehub/android/ThaliDeviceHubService.java
+++ b/Production/ThaliDeviceHub/android/android/src/main/java/com/msopentech/thali/devicehub/android/ThaliDeviceHubService.java
@@ -58,6 +58,7 @@ public class ThaliDeviceHubService extends Service {
     public static final String HttpKeysNotification = "com.msopentech.thali.devicehub.android.httpkeys";
     public static final String LocalMachineIPHttpKeyURLName = "LocalMachineIPHttpKeyURL";
     public static final String OnionHttpKeyURLName = "OnionHttpKeyURLName";
+    public static final String SocksOnionProxyPort = "SocksOnionProxyPort";
     protected ThaliListener thaliListener = null;
 
     // These values are used for testing
@@ -105,6 +106,7 @@ public class ThaliDeviceHubService extends Service {
                 try {
                     httpKeysIntent.putExtra(LocalMachineIPHttpKeyURLName, thaliListener.getHttpKeys().getLocalMachineIPHttpKeyURL());
                     httpKeysIntent.putExtra(OnionHttpKeyURLName, thaliListener.getHttpKeys().getOnionHttpKeyURL());
+                    httpKeysIntent.putExtra(SocksOnionProxyPort, thaliListener.getHttpKeys().getSocksOnionProxyPort());
                     sendBroadcast(httpKeysIntent);
                     httpKeysSentByBroadcast = true;
                     return;

--- a/Production/Utilities/AndroidUtilities/AndroidUtilities/src/androidTest/java/com/msopentech/thali/utilities/test/RestTestMethods.java
+++ b/Production/Utilities/AndroidUtilities/AndroidUtilities/src/androidTest/java/com/msopentech/thali/utilities/test/RestTestMethods.java
@@ -72,7 +72,7 @@ public class RestTestMethods extends UtilitiesTestCase {
             }
         }
         HttpResponse httpResponse = httpClient.execute(httpUriRequest);
-        assertEquals(httpResponse.getStatusLine().getStatusCode(), statusCode);
+        assertEquals(statusCode, httpResponse.getStatusLine().getStatusCode());
         testHeaders(httpResponse, headersToFind);
         return httpResponse;
     }

--- a/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/CouchDBListener/BogusThaliAuthorizerFactory.java
+++ b/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/CouchDBListener/BogusThaliAuthorizerFactory.java
@@ -91,6 +91,7 @@ public class BogusThaliAuthorizerFactory implements AuthorizerFactory {
             // up possible security holes. We need to think this through.
             // TODO: We really need to support local to local replication in a more secure way, looking to match addresses
             // just feels like some weird unicode security hole waiting to happen.
+            // https://github.com/thaliproject/thali/issues/69
             boolean doNotUseProxy = httpKeyURL.getHost().endsWith(".onion") == false;
 
             return new BogusThaliAuthorizer(httpKeyURL.getServerPublicKey(), clientKeyStore, clientPassPhrase,

--- a/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/CouchDBListener/HttpKeyTypes.java
+++ b/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/CouchDBListener/HttpKeyTypes.java
@@ -19,6 +19,7 @@ import com.msopentech.thali.utilities.universal.HttpKeyURL;
 public class HttpKeyTypes {
     protected String localMachineIPHttpKeyURL = null;
     protected String onionHttpKeyURL = null;
+    protected String socksOnionProxyPort = null;
 
     /**
      * This constructor is just meant for use when parsing from JSON.
@@ -28,9 +29,10 @@ public class HttpKeyTypes {
 
     }
 
-    public HttpKeyTypes(HttpKeyURL localMachineIpHttpKeyUrl, HttpKeyURL onionHttpKeyURL) {
+    public HttpKeyTypes(HttpKeyURL localMachineIpHttpKeyUrl, HttpKeyURL onionHttpKeyURL, Integer socksOnionProxyPort) {
         this.localMachineIPHttpKeyURL = localMachineIpHttpKeyUrl.toString();
         this.onionHttpKeyURL = onionHttpKeyURL.toString();
+        this.socksOnionProxyPort = socksOnionProxyPort.toString();
     }
 
     public String getLocalMachineIPHttpKeyURL() {
@@ -47,5 +49,13 @@ public class HttpKeyTypes {
 
     public void setOnionHttpKeyURL(String onionHttpKeyURL) {
         this.onionHttpKeyURL = onionHttpKeyURL;
+    }
+
+    public String getSocksOnionProxyPort() {
+        return socksOnionProxyPort;
+    }
+
+    public void setSocksOnionProxyPort(String socksOnionProxyPort) {
+        this.socksOnionProxyPort = socksOnionProxyPort;
     }
 }

--- a/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/CouchDBListener/ThaliListener.java
+++ b/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/CouchDBListener/ThaliListener.java
@@ -280,6 +280,6 @@ public class ThaliListener {
         int portToUseForHttpKey = getSocketStatus().getPort();
         String host = InetAddress.getLocalHost().getHostAddress();
         HttpKeyURL localHttpKeyURL = new HttpKeyURL(serverPublicKey, host, portToUseForHttpKey, null, null, null);
-        return new HttpKeyTypes(localHttpKeyURL, hiddenServiceAddress);
+        return new HttpKeyTypes(localHttpKeyURL, hiddenServiceAddress, onionProxyManager.getIPv4LocalHostSocksPort());
     }
 }

--- a/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/utilities/universal/HttpKeyHttpClient.java
+++ b/Production/Utilities/UniversalUtilities/src/main/java/com/msopentech/thali/utilities/universal/HttpKeyHttpClient.java
@@ -68,15 +68,18 @@ http://www.gnu.org/licenses/lgpl.html
 package com.msopentech.thali.utilities.universal;
 
 import com.msopentech.thali.toronionproxy.OsData;
-import org.apache.http.conn.*;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.ClientConnectionOperator;
 import org.apache.http.conn.params.ConnManagerParams;
 import org.apache.http.conn.params.ConnPerRouteBean;
-import org.apache.http.conn.scheme.*;
-import org.apache.http.impl.client.*;
-import org.apache.http.impl.conn.tsccm.*;
-import org.apache.http.params.*;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
+import org.apache.http.params.HttpParams;
 
-import java.net.*;
+import java.net.Proxy;
 import java.security.*;
 
 /**
@@ -98,7 +101,7 @@ public class HttpKeyHttpClient extends DefaultHttpClient {
                 clientKeyStorePassPhrase);
         schemeRegistry.register((new Scheme("https", httpKeySSLSocketFactory, 443)));
 
-        // Try to up retries to deal with how flakey the Tor Hidden Service channels seem to be.
+        // Try to up retries to deal with how flaky the Tor Hidden Service channels seem to be.
         // Note that modern Apache would set this via a Param but that Param doesn't seem to exist
         // in Android land. This sucks because we can't be sure if the user is using the default
         // retry handler or different one. And no, comparing getHttpRequestRetryHandler() against

--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -65,7 +65,7 @@ task buildTorOnionProxyLibraryUniversal(type: GradleBuild) {
 
 task buildTorOnionProxyLibraryJava(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryUniversal') {
     buildFile = '../../Tor_Onion_Proxy_Library/java/build.gradle'
-    tasks = runJavaTest('uploadArchives', false)
+    tasks = runJavaTest('uploadArchives')
 }
 
 task buildTorOnionProxyLibraryAndroid(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryJava') {

--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -65,7 +65,7 @@ task buildTorOnionProxyLibraryUniversal(type: GradleBuild) {
 
 task buildTorOnionProxyLibraryJava(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryUniversal') {
     buildFile = '../../Tor_Onion_Proxy_Library/java/build.gradle'
-    tasks = runJavaTest('uploadArchives')
+    tasks = runJavaTest('uploadArchives', false)
 }
 
 task buildTorOnionProxyLibraryAndroid(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryJava') {
@@ -130,7 +130,7 @@ task buildThaliDeviceHubUniversal(type: GradleBuild, dependsOn: 'buildThaliAndro
 
 task buildThaliDeviceHubJava(type: GradleBuild, dependsOn: 'buildThaliDeviceHubUniversal') {
     buildFile = 'ThaliDeviceHub/java/build.gradle'
-    tasks = runJavaTest('distZip') // This isn't a library, it's an 'executable', this builds the distribution
+    tasks = runJavaTest('installApp') // This isn't a library, it's an 'executable', this builds the distribution
 }
 
 task buildThaliDeviceHubAndroid(type: GradleBuild, dependsOn: 'buildThaliDeviceHubJava') {


### PR DESCRIPTION
To jog the readers memory, our Javascript based QRCode reading system can't handle very large QR Codes. So we worked around this by only displaying a TDH's onion domain address (which is tiny) and port. We then needed the relay to translate that address/port into a full httpkey URL by connecting to the onion address via Tor and pulling down the server's key. Unfortunately I forgot to hook up the code that does this resolution to the Tor Socks proxy in my last check in so this one fixes that and also updates the TDH to publish to the relay what its socks proxy address is.

I also did some test refactoring and fixed an annoying bug in Android's HTTPClient that it doesn't properly honor retry handling on ioexceptions from the network connection layer (where we do our SSL voodoo). Eventually we need to update to Apache's support Android releases and get off the stock Android Apache code.
