### PR TITLE
Support install task and SNAPSHOT version

### DIFF
--- a/Production/ThaliDeviceHub/Universal/build.gradle
+++ b/Production/ThaliDeviceHub/Universal/build.gradle
@@ -17,6 +17,10 @@ apply plugin: 'maven'
 // Needed to keep Android happy
 sourceCompatibility = '1.6'
 
+version = System.getProperty('MAVEN_UPLOAD_VERSION')
+group = 'com.msopentech.thali'
+archivesBaseName = 'ThaliTDHUniversal'
+
 repositories {
     mavenLocal()
     maven { url "http://thaliartifactory.cloudapp.net/artifactory/libs-snapshot" }
@@ -39,9 +43,6 @@ uploadArchives {
                 authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD')) 
             }
 
-            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
-            pom.groupId = 'com.msopentech.thali'
-            pom.artifactId = 'ThaliTDHUniversal'
             pom.project {
                 licenses {
                     license {

--- a/Production/ThaliDeviceHub/Universal/build.gradle
+++ b/Production/ThaliDeviceHub/Universal/build.gradle
@@ -62,7 +62,7 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 task generateJavadocs(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
-    source = sourceSets.main.java.srcDirs
+    from javadoc.destinationDir
 }
 
 artifacts {

--- a/Production/ThaliDeviceHub/java/build.gradle
+++ b/Production/ThaliDeviceHub/java/build.gradle
@@ -18,6 +18,10 @@ apply plugin: 'maven'
 
 mainClassName = "com.msopentech.thali.devicehub.javahub.main"
 
+version = System.getProperty('MAVEN_UPLOAD_VERSION')
+group = 'com.msopentech.thali'
+archivesBaseName = 'ThaliDeviceHubJava'
+
 repositories {
     mavenLocal()
     maven { url "http://thaliartifactory.cloudapp.net/artifactory/libs-snapshot" }

--- a/Production/ThaliDeviceHub/java/build.gradle
+++ b/Production/ThaliDeviceHub/java/build.gradle
@@ -42,7 +42,7 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 task generateJavadocs(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
-    source = sourceSets.main.java.srcDirs
+    from javadoc.destinationDir
 }
 
 artifacts {

--- a/Production/Utilities/AndroidUtilities/AndroidUtilities/build.gradle
+++ b/Production/Utilities/AndroidUtilities/AndroidUtilities/build.gradle
@@ -17,11 +17,16 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:0.10.+'
+        classpath 'com.github.dcendents:android-maven-plugin:1.1'
     }
 }
 
 apply plugin: 'android-library'
-apply plugin: 'maven'
+apply plugin: 'android-maven'
+
+version = System.getProperty('MAVEN_UPLOAD_VERSION')
+group = 'com.msopentech.thali'
+archivesBaseName = 'ThaliUtilitiesAndroid'
 
 repositories {
     mavenLocal()
@@ -72,9 +77,6 @@ uploadArchives {
                 authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD')) 
             }
 
-            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
-            pom.groupId = 'com.msopentech.thali'
-            pom.artifactId = 'ThaliUtilitiesAndroid'
             pom.project {
                 licenses {
                     license {

--- a/Production/Utilities/JavaUtilities/build.gradle
+++ b/Production/Utilities/JavaUtilities/build.gradle
@@ -18,6 +18,10 @@ apply plugin: 'java-library-distribution'
 
 sourceCompatibility = '1.6'
 
+version = System.getProperty('MAVEN_UPLOAD_VERSION')
+group = 'com.msopentech.thali'
+archivesBaseName = 'ThaliUtilitiesJava'
+
 repositories {
     mavenLocal()
     maven { url "http://thaliartifactory.cloudapp.net/artifactory/libs-snapshot" }
@@ -49,9 +53,6 @@ uploadArchives {
                 authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD')) 
             }
 
-            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
-            pom.groupId = 'com.msopentech.thali'
-            pom.artifactId = 'ThaliUtilitiesJava'
             pom.project {
                 licenses {
                     license {

--- a/Production/Utilities/JavaUtilities/build.gradle
+++ b/Production/Utilities/JavaUtilities/build.gradle
@@ -72,7 +72,7 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 task generateJavadocs(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
-    source = sourceSets.main.java.srcDirs
+    from javadoc.destinationDir
 }
 
 artifacts {

--- a/Production/Utilities/UniversalUtilities/build.gradle
+++ b/Production/Utilities/UniversalUtilities/build.gradle
@@ -17,6 +17,10 @@ apply plugin: 'maven'
 // Needed to keep Android happy
 sourceCompatibility = '1.6'
 
+version = System.getProperty('MAVEN_UPLOAD_VERSION')
+group = 'com.msopentech.thali'
+archivesBaseName = 'ThaliUtilitiesUniversal'
+
 repositories {
     mavenLocal()
     maven { url "http://thaliartifactory.cloudapp.net/artifactory/libs-snapshot" }
@@ -48,9 +52,6 @@ uploadArchives {
                 authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD')) 
             }
 
-            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
-            pom.groupId = 'com.msopentech.thali'
-            pom.artifactId = 'ThaliUtilitiesUniversal'
             pom.project {
                 licenses {
                     license {

--- a/Production/Utilities/UniversalUtilities/build.gradle
+++ b/Production/Utilities/UniversalUtilities/build.gradle
@@ -69,12 +69,12 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.java.srcDirs
 }
 
-task generateJavadocs(type: Jar, dependsOn: javadoc) {
+task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
-    source = sourceSets.main.java.srcDirs
+    from javadoc.destinationDir
 }
 
 artifacts {
     archives sourcesJar
-    archives generateJavadocs
+    archives javadocJar 
 }

--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -53,32 +53,35 @@ def getAllProjects() {
     ]
 }
 
-task cleanAll(type:GradleBuild) << {
+/**
+ * Launch Gradle against each subproject
+ *
+ * @param startParameter        Gradle project's start parameter
+ * @param task                  Name of Gradle task to execute
+ * @param runTaskArgumentOnly   If set to true, will execute 'task' argument only. 
+ *                              Otherwise, will prepend default tasks defined by getAllProjects()
+ * @param runTaskAgainstTdh     If set to true, Gradle task will be executed against all subprojects
+ *                              Otherwise, TDH/Android and TDH/java will be special cased
+ */
+def launchGradle(startParameter, task, runTaskArgumentOnly = true, runTaskAgainstTdh = true) {
     getAllProjects().each { thaliProject ->
+        // build file
         def buildFile = new File(thaliProject[0])
-        logger.info buildFile 
-        StartParameter params = new StartParameter()
-        params.setTaskNames(['clean'])
-        params.buildFile = buildFile
-        GradleLauncher.newInstance(params).run().rethrowFailure()
-    }
-}
+        logger.info task + ': BuildFile: ' + buildFile
 
-task installAll(type:GradleBuild) << {
-    getAllProjects().each { thaliProject ->
-        def buildFile = new File(thaliProject[0])
-        logger.info 'installAll: BuildFile: ' + buildFile
+        def tasks = (runTaskArgumentOnly) ? [] : thaliProject[1]
+        tasks.add(task)
 
-        def tasks = thaliProject[1]
-        tasks.add('install')
-        if (buildFile.toString().contains('ThaliDeviceHub') &&
-            buildFile.toString().contains('android')) {
-            // if this is ThaliDeviceHub/android, remove install task
-            tasks.remove('install')
+        if (!runTaskAgainstTdh) {
+            if (buildFile.toString().contains('ThaliDeviceHub') &&
+                (buildFile.toString().contains('android') || buildFile.toString().contains('java'))) {
+                // if this is TDH/java or TDH/android, remove install task
+                tasks.remove(task)
+            }
         }
 
         tasks.removeAll([null])
-        logger.info 'installAll: Tasks: ' + tasks
+        logger.info task + ': Tasks: ' + tasks
 
         def params = project.gradle.startParameter.newBuild()
         params.setTaskNames(tasks)
@@ -90,35 +93,21 @@ task installAll(type:GradleBuild) << {
     }
 }
 
+task cleanAll(type:GradleBuild) << {
+    launchGradle(startParameter, 'clean', true, true)
+}
+
+task installAll(type:GradleBuild) << {
+    launchGradle(startParameter, 'install', false, false)
+}
+
 task uploadArchivesAll(type:GradleBuild) << {
-    getAllProjects().each { thaliProject ->
-        def buildFile = new File(thaliProject[0])
-        logger.info 'uploadArchivesAll: BuildFile: ' + buildFile
-
-        def tasks = thaliProject[1]
-        tasks.add('uploadArchives')
-        if (buildFile.toString().contains('ThaliDeviceHub') &&
-            buildFile.toString().contains('android')) {
-            // if this is ThaliDeviceHub/android, remove uploadArchives task
-            tasks.remove('uploadArchives')
-        }
-
-        tasks.removeAll([null])
-        logger.info 'uploadArchivesAll: Tasks: ' + tasks
-
-        def params = project.gradle.startParameter.newBuild()
-        params.setTaskNames(tasks)
-        params.buildFile = buildFile
-        params.projectProperties = startParameter.projectProperties
-        params.systemPropertiesArgs = startParameter.systemPropertiesArgs
- 
-        GradleLauncher.newInstance(params).run().rethrowFailure()
-    }
+    launchGradle(startParameter, 'uploadArchives', false, false)
 }
 
 tasks.withType(GradleBuild) {
     ext.buildWithArtifacts = 'true'
-    ext.buildVersion = System.getProperty('MAVEN_UPLOAD_VERSION') ?: '1.0.0-beta3rc1'
+    ext.buildVersion = System.getProperty('MAVEN_UPLOAD_VERSION')
 
     startParameter.projectProperties = gradle.startParameter.projectProperties
     startParameter.systemPropertiesArgs = [
@@ -133,11 +122,6 @@ tasks.withType(GradleBuild) {
         'buildListenerWithArtifacts': buildWithArtifacts,
         'buildAgainstMavenArtifacts': buildWithArtifacts,
     ]
-}
-
-
-task globalBuild(dependsOn: 'uploadArchivesAll'){
-    // task left here for those that are still used to using globalBuild
 }
 
 

--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -2,7 +2,22 @@ apply plugin: 'java'
 apply plugin: 'distribution'
 
 sourceCompatibility = 1.6
-version = System.getProperty('MAVEN_UPLOAD_VERSION') ?: '1.0.0-beta3rc1'
+
+def androidTestTask(include = true) {
+   if (include == false || project.hasProperty('skipAndroidTest') || project.hasProperty('skipAllTest')) {
+        return null
+   } else {
+        return 'connectedAndroidTest';
+   }
+}
+
+def testTask(include = true) {
+    if (include == false || project.hasProperty('skipJavaTest') || project.hasProperty('skipAllTest')) {
+        return null
+    }
+
+    return 'test'
+}
 
 /*
 This script depends on the layout of depots. It assumes a file structure of
@@ -13,40 +28,96 @@ some directory
 
 In other words that there is a single directory that contains all the relevant depots below including Thali.
  */
-
-// You can pass in -PcleanAll on the command line to do a clean
-// You can pass in -PskipAndroidTest on the command line to skip android tests
-def runAndroidTest(buildTask, runTest = true) {
-   if (project.hasProperty('cleanAll')) {
-	   return [ 'clean' ];
-   }
-   
-   if (runTest == false || project.hasProperty('skipAndroidTest') || project.hasProperty('skipAllTest')) {
-       return [ buildTask ];
-   } else {
-       return ['connectedAndroidTest', buildTask];
-   }
+def getAllProjects() {
+    return [
+        ['../../Tor_Onion_Proxy_Library/universal/build.gradle',    [testTask()]],
+        ['../../Tor_Onion_Proxy_Library/java/build.gradle',         [testTask()]],
+        ['../../Tor_Onion_Proxy_Library/android/build.gradle',      [androidTestTask()]],
+        ['../../couchbase-lite-java-native/build.gradle',           [testTask()]],
+        ['../../couchbase-lite-java-core/build.gradle',             [testTask()]],
+        ['../../couchbase-lite-java-listener/build.gradle',         [testTask()]],
+        ['../../couchbase-lite-android/build.gradle',               [androidTestTask(false)]],
+        ['../../couchbase-lite-java/build.gradle',                  [testTask(false)]],
+        ['Utilities/UniversalUtilities/build.gradle',               [testTask()]],
+        ['Utilities/JavaUtilities/build.gradle',                    [testTask()]],
+        ['Utilities/AndroidUtilities/build.gradle',                 [androidTestTask()]],
+        ['ThaliDeviceHub/Universal/build.gradle',                   [testTask()]],
+        ['ThaliDeviceHub/java/build.gradle',                        [testTask(), 'distZip']],
+        ['ThaliDeviceHub/android/android/build.gradle',             [testTask(), 'build']]
+    ]
 }
 
-def runJavaTest(buildTask, runTest = true) {
-    if (project.hasProperty('cleanAll')) {
-	  return [ 'clean' ];
-	}
-	
-	if (runTest == false || project.hasProperty('skipJavaTest') || project.hasProperty('skipAllTest')) {
-		return [ buildTask];
-	} else {
-		return ['test', buildTask];
-	}
+task cleanAll(type:GradleBuild) << {
+    getAllProjects().each { thaliProject ->
+        def buildFile = new File(thaliProject[0])
+        logger.info buildFile 
+        StartParameter params = new StartParameter()
+        params.setTaskNames(['clean'])
+        params.buildFile = buildFile
+        GradleLauncher.newInstance(params).run().rethrowFailure()
+    }
 }
+
+task installAll(type:GradleBuild) << {
+    getAllProjects().each { thaliProject ->
+        def buildFile = new File(thaliProject[0])
+        logger.info 'installAll: BuildFile: ' + buildFile
+
+        def tasks = thaliProject[1]
+        tasks.add('install')
+        if (buildFile.toString().contains('ThaliDeviceHub') &&
+            buildFile.toString().contains('android')) {
+            // if this is ThaliDeviceHub/android, remove install task
+            tasks.remove('install')
+        }
+
+        tasks.removeAll([null])
+        logger.info 'installAll: Tasks: ' + tasks
+
+        def params = project.gradle.startParameter.newBuild()
+        params.setTaskNames(tasks)
+        params.buildFile = buildFile
+        params.projectProperties = startParameter.projectProperties
+        params.systemPropertiesArgs = startParameter.systemPropertiesArgs
+        
+       // GradleLauncher.newInstance(params).run().rethrowFailure()
+    }
+}
+
+task uploadArchivesAll(type:GradleBuild) << {
+    getAllProjects().each { thaliProject ->
+        def buildFile = new File(thaliProject[0])
+        logger.info 'uploadArchivesAll: BuildFile: ' + buildFile
+
+        def tasks = thaliProject[1]
+        tasks.add('uploadArchives')
+        if (buildFile.toString().contains('ThaliDeviceHub') &&
+            buildFile.toString().contains('android')) {
+            // if this is ThaliDeviceHub/android, remove uploadArchives task
+            tasks.remove('uploadArchives')
+        }
+
+        tasks.removeAll([null])
+        logger.info 'uploadArchivesAll: Tasks: ' + tasks
+
+        def params = project.gradle.startParameter.newBuild()
+        params.setTaskNames(tasks)
+        params.buildFile = buildFile
+        params.projectProperties = startParameter.projectProperties
+        params.systemPropertiesArgs = startParameter.systemPropertiesArgs
  
+        GradleLauncher.newInstance(params).run().rethrowFailure()
+    }
+}
+
 tasks.withType(GradleBuild) {
     ext.buildWithArtifacts = 'true'
+    ext.buildVersion = System.getProperty('MAVEN_UPLOAD_VERSION') ?: '1.0.0-beta3rc1'
 
     startParameter.projectProperties = gradle.startParameter.projectProperties
     startParameter.systemPropertiesArgs = [
-        'UPLOAD_VERSION_CBLITE'     : version,
-        'MAVEN_UPLOAD_VERSION'      : version,
+        'UPLOAD_VERSION_CBLITE'     : buildVersion,
+        'MAVEN_UPLOAD_VERSION'      : buildVersion,
         'MAVEN_UPLOAD_REPO_URL'     : System.getProperty('MAVEN_UPLOAD_REPO_URL'),
         'MAVEN_UPLOAD_USERNAME'     : System.getProperty('MAVEN_UPLOAD_USERNAME'),
         'MAVEN_UPLOAD_PASSWORD'     : System.getProperty('MAVEN_UPLOAD_PASSWORD'),
@@ -58,87 +129,7 @@ tasks.withType(GradleBuild) {
     ]
 }
 
-task buildTorOnionProxyLibraryUniversal(type: GradleBuild) {
-    buildFile = '../../Tor_Onion_Proxy_Library/universal/build.gradle'
-    tasks = runJavaTest('uploadArchives')
-}
-
-task buildTorOnionProxyLibraryJava(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryUniversal') {
-    buildFile = '../../Tor_Onion_Proxy_Library/java/build.gradle'
-    tasks = runJavaTest('uploadArchives')
-}
-
-task buildTorOnionProxyLibraryAndroid(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryJava') {
-    buildFile = '../../Tor_Onion_Proxy_Library/android/build.gradle'
-    tasks = runAndroidTest('uploadArchives')
-}
-
-// Note that if you get a broken build with link errors the only way to get things going again is
-// to execute a clean in the tasks list below. Also note that in windows I
-// can only get this to build from a command window, not from the Git MINGW32
-// window I normally use.
-task buildCouchbaseLiteJavaNative(type: GradleBuild, dependsOn: 'buildTorOnionProxyLibraryAndroid') {
-    buildFile = '../../couchbase-lite-java-native/build.gradle'
-    tasks = runJavaTest('uploadArchives')
-}
-
-task buildCouchbaseLiteJavaCore(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaNative') {
-    buildFile = '../../couchbase-lite-java-core/build.gradle'
-    tasks = runJavaTest('uploadArchives')
-}
-
-task buildCouchbaseLiteJavaListener(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaCore') {
-    buildFile = '../../couchbase-lite-java-listener/build.gradle'
-    tasks = runJavaTest('uploadArchives')
-}
-
-// See issue 53 in the next task
-task buildCouchbaseLiteAndroid(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJavaListener') {
-    buildFile = '../../couchbase-lite-android/build.gradle'
-    tasks = runAndroidTest('uploadArchives', false)
-}
-
-// Couchbase Lite currently requires syncgateway to test or a special
-// config that supports listener. But in newer releases of the gateway this
-// was all fixed and uses mocks. We aren't going to upgrade right now for
-// stability reasons so we are turning off the tests until we get the upgrade.
-// https://github.com/thaliproject/thali/issues/53
-task buildCouchbaseLiteJava(type: GradleBuild, dependsOn: 'buildCouchbaseLiteAndroid') {
-    buildFile = '../../couchbase-lite-java/build.gradle'
-    tasks = runJavaTest('uploadArchives', false)
-}
-
-task buildThaliUniversalUtilities(type: GradleBuild, dependsOn: 'buildCouchbaseLiteJava') {
-    buildFile = 'Utilities/UniversalUtilities/build.gradle'
-    tasks = runJavaTest('uploadArchives')
-}
-
-task buildThaliJavaUtilities(type: GradleBuild, dependsOn: 'buildThaliUniversalUtilities') {
-    buildFile = 'Utilities/JavaUtilities/build.gradle'
-    tasks = runJavaTest('uploadArchives')
-}
-
-task buildThaliAndroidUtilities(type: GradleBuild, dependsOn: 'buildThaliJavaUtilities') {
-    buildFile = 'Utilities/AndroidUtilities/build.gradle'
-    tasks = runAndroidTest('uploadArchives')
-}
-
-task buildThaliDeviceHubUniversal(type: GradleBuild, dependsOn: 'buildThaliAndroidUtilities') {
-    buildFile = 'ThaliDeviceHub/Universal/build.gradle'
-    tasks = runJavaTest('uploadArchives')
-}
-
-task buildThaliDeviceHubJava(type: GradleBuild, dependsOn: 'buildThaliDeviceHubUniversal') {
-    buildFile = 'ThaliDeviceHub/java/build.gradle'
-    tasks = runJavaTest('distZip') // This isn't a library, it's an 'executable', this builds the distribution
-}
-
-task buildThaliDeviceHubAndroid(type: GradleBuild, dependsOn: 'buildThaliDeviceHubJava') {
-    buildFile = 'ThaliDeviceHub/android/android/build.gradle'
-    tasks = runAndroidTest('build') // This isn't a library, it's an 'executable', this builds the apk file
-}
-
-task globalBuild(dependsOn: 'buildThaliDeviceHubAndroid'){}
+task globalBuild(dependsOn: installAll){}
 
 // BUILD THE PPNET DEMO
 
@@ -198,6 +189,3 @@ distZip.dependsOn deletePouchAPKFromChromeExtension
 
 task buildPPNETDemo(dependsOn: distZip) {
 }
-
-
-

--- a/README.md
+++ b/README.md
@@ -4,5 +4,3 @@ thali
 An experiment to see what it would take to make the web truly Peer to Peer
 
 Please see http://www.thaliproject.org/mediawiki/index.php?title=Main_Page for more information.
-
-

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ thali
 An experiment to see what it would take to make the web truly Peer to Peer
 
 Please see http://www.thaliproject.org/mediawiki/index.php?title=Main_Page for more information.
+
+


### PR DESCRIPTION
- Add installAll, uploadArchivesAll, cleanAll build tasks. 
- installAll: should be used for building locally
- uploadArchivesAll: to be used for uploading to remote artifactory
- cleanAll: will call clean task of each build.gradle

Example:
// the following command will upload a SNAPSHOT version to the artifactory
// gradle/maven will update "SNAPSHOT" in the version number with the current datetime

> gradlew installAll -DMAVEN_UPLOAD_VERSION=0.0.0-SNAPSHOT -DMAVEN_UPLOAD_REPO_URL=http://thaliartifactory.cloudapp.net/artifactory/libs-snapshot-local -info

Bug Fixes:
- Fix generation of java doc jars
