### PR TITLE
Fix ugly names

### DIFF
--- a/Production/ThaliDeviceHub/android/android/build.gradle
+++ b/Production/ThaliDeviceHub/android/android/build.gradle
@@ -36,6 +36,22 @@ android {
         pickFirst 'BridgeHandlerTest.js' // Causing a double import of ThaliUtilitiesUniversal for no apparent reason
         pickFirst 'BridgeManager.js' // See previous
     }
+
+    buildTypes {
+        // See http://stackoverflow.com/questions/18332474/how-to-set-versionname-in-apk-filename-using-gradle for
+        // how to handle a signed release
+        debug {
+            applicationVariants.all { variant ->
+                def file = variant.outputFile
+                // Because the project is called android the default output name would be
+                // android-debug-unaligned.apk. We diff off that.
+                variant.outputFile =
+                        new File(file.parent,
+                                file.name.replace("android",
+                                        "thali-device-hub-" + System.getProperty('MAVEN_UPLOAD_VERSION')));
+            }
+        }
+    }
 }
 
 dependencies {

--- a/Production/ThaliDeviceHub/java/build.gradle
+++ b/Production/ThaliDeviceHub/java/build.gradle
@@ -16,11 +16,16 @@ apply plugin: 'java'
 apply plugin: 'maven'
 //apply from: 'javafx.plugin'
 
+// Naming our jar 'java' is less than useful.
+jar.baseName 'ThaliDeviceHub'
+
+// Gives our scripts for distZip a more useful name
+startScripts.applicationName "start" + jar.baseName
+
 mainClassName = "com.msopentech.thali.devicehub.javahub.main"
 
 version = System.getProperty('MAVEN_UPLOAD_VERSION')
 group = 'com.msopentech.thali'
-archivesBaseName = 'ThaliDeviceHubJava'
 
 repositories {
     mavenLocal()
@@ -39,6 +44,8 @@ dependencies {
     testCompile 'junit:junit:4.11'
 }
 
+distZip.baseName 'ThaliDeviceHub'
+
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.java.srcDirs
@@ -53,3 +60,33 @@ artifacts {
     archives sourcesJar
     archives generateJavadocs
 }
+
+
+def tempOutputDir = file("${buildDir}/unpacked/dist")
+
+task deleteOldUnzip(type:Delete, dependsOn: distZip) {
+    delete tempOutputDir
+}
+
+task unzipDistZip(type: Copy, dependsOn: deleteOldUnzip) {
+    def zipFile = file(distZip.archivePath)
+    from zipTree(zipFile)
+    into tempOutputDir
+}
+
+task deleteOldZip(type: Delete, dependsOn: unzipDistZip) {
+    delete distZip.archivePath
+}
+
+def unzipDirectoryRoot = file(tempOutputDir.path + "/" +
+        distZip.archiveName.substring(0, distZip.archiveName.length() - 1 - distZip.extension.length()))
+
+// The distZip file contains an extra directory at the root with the same name as the zip file. I'm sure
+// there is some switch to make it not do that but I haven't found it. So instead I unzip the file, move
+// it's contents and then re-zip but skip that extra directory.
+task skipLevelZip(type: Zip, dependsOn: deleteOldZip) {
+    from unzipDirectoryRoot
+    baseName distZip.baseName
+}
+
+task zipAndInstall(dependsOn: ['installApp', 'skipLevelZip']) {}

--- a/Production/build.gradle
+++ b/Production/build.gradle
@@ -48,7 +48,7 @@ def getAllProjects() {
         ['Utilities/JavaUtilities/build.gradle',                    [testTask()]],
         ['Utilities/AndroidUtilities/build.gradle',                 [androidTestTask()]],
         ['ThaliDeviceHub/Universal/build.gradle',                   [testTask()]],
-        ['ThaliDeviceHub/java/build.gradle',                        [testTask(), 'installApp']],
+        ['ThaliDeviceHub/java/build.gradle',                        [testTask(), 'zipAndInstall']],
         ['ThaliDeviceHub/android/android/build.gradle',             [androidTestTask(), 'build']]
     ]
 }


### PR DESCRIPTION
We changed the APK name for the TDH to be more human readable and
we fixed the distZip to both have a more readable name, to remove
the extraneous directory that distZip puts in the root of the zip file
and to give the start script a clearer name.
