### PR TITLE
Create 2015-03-09-Acceptance-dialog-with-Wifi-Direct-connections.md

### DIFF
--- a/_posts/2015-03-09-Acceptance-dialog-with-Wifi-Direct-connections.md
+++ b/_posts/2015-03-09-Acceptance-dialog-with-Wifi-Direct-connections.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: UX with Wifi Direct: The connection acceptance dialog
+---
+
+When connecting devices with Wifi direct API, there are acceptance dialogs shown to ask users permission for establishing connections.
+
+This post identifies when these dialogs are shown, read more from the [blog article](http://www.drjukka.com/blog/wordpress/?p=35)


### PR DESCRIPTION
---

layout: post
## title: UX with Wifi Direct: The connection acceptance dialog

When connecting devices with Wifi direct API, there are acceptance dialogs shown to ask users permission for establishing connections.

This post identifies when these dialogs are shown, read more from the [blog article](http://www.drjukka.com/blog/wordpress/?p=35)
