### PR TITLE
Create 2015-03-09-Wifi-Direct-connections-without-dialogs.md

### DIFF
--- a/_posts/2015-03-09-Wifi-Direct-connections-without-dialogs.md
+++ b/_posts/2015-03-09-Wifi-Direct-connections-without-dialogs.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: Wifi direct, connections without User interaction
+---
+
+When connecting devices with Wifi direct API, there are acceptance dialogs shown to ask users permission for establishing connections.
+
+This post identifies ways on getting rid of these dialogs, read more from the [blog article](http://www.drjukka.com/blog/wordpress/?p=39)


### PR DESCRIPTION
---

layout: post
## title: Wifi direct, connections without User interaction

When connecting devices with Wifi direct API, there are acceptance dialogs shown to ask users permission for establishing connections.

This post identifies ways on getting rid of these dialogs, read more from the [blog article](http://www.drjukka.com/blog/wordpress/?p=39)
