### PR TITLE
Create 2015-03-18-Wifi-pairing.md

### DIFF
--- a/_posts/2015-03-18-Wifi-pairing.md
+++ b/_posts/2015-03-18-Wifi-pairing.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: Wifi pairing
+---
+Earlier I suggested that the Known groups for Wifi Direct could be teached for the device.
+Thus making the Wifi direct "pairable" same way as Bluetooth.
+
+Fianlyl got to check how it would work out, and results are [here](http://www.drjukka.com/blog/wordpress/?p=46).

--- a/_posts/2015-03-18-Wifi-pairing.md
+++ b/_posts/2015-03-18-Wifi-pairing.md
@@ -2,7 +2,7 @@
 layout: post
 title: Wifi pairing
 ---
-Earlier I suggested that the Known groups for Wifi Direct could be teached for the device.
-Thus making the Wifi direct "pairable" same way as Bluetooth.
 
-Fianlyl got to check how it would work out, and results are [here](http://www.drjukka.com/blog/wordpress/?p=46).
+Wifi Direct on Android requires user confirmation to establish a connection, we could then treat as  piaring, similarly as is required with like Bluetooth. Once two devices are 'paired' they can communicate over Wifi Direct in the background or the foreground without any further user confirmations! This opens up Wifi Direct's longer range and higher bandwidth as an alternative to unauthenticated Bluetooth connections.
+
+Read the rest from [the blog](http://www.drjukka.com/blog/wordpress/?p=46).


### PR DESCRIPTION
---

layout: post
## title: Wifi pairing

I had [previously](http://www.drjukka.com/blog/wordpress/?p=39) suggested that one could teach a WiFi Direct device about "known" groups creating a "pairing" experience similar to Bluetooth and getting rid of multiple wi-fi acceptance dialogs.

Finally I got to run tests on the idea, and results are [here](http://www.drjukka.com/blog/wordpress/?p=46).
