### PR TITLE
Create 2015-04-09-Android-P2P-First-library-release.md

### DIFF
--- a/_posts/2015-04-09-Android-P2P-First-library-release.md
+++ b/_posts/2015-04-09-Android-P2P-First-library-release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: First library release
+---
+Got first Alpha level library published for P2P on android. With teh first release the Wifi Direct is used for discovery parts, and for data exchange the library is using unsecure Bluetooth sockets.
+
+Find more info and links to videos from m  [blog article](http://www.drjukka.com/blog/wordpress/?p=75)


### PR DESCRIPTION
---

layout: post
## title: First library release

Got first Alpha level library published for P2P on android. With teh first release the Wifi Direct is used for discovery parts, and for data exchange the library is using unsecure Bluetooth sockets.

Find more info and links to videos from m  [blog article](http://www.drjukka.com/blog/wordpress/?p=75)
